### PR TITLE
build: add conditional compilation attribute to language detection tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ overhead when embedding in this mode.
 ```rust
 use bm25::{Embedder, EmbedderBuilder, LanguageMode};
 
+#[cfg(feature = "language_detection")]
 let embedder: Embedder = EmbedderBuilder::with_avgdl(64.0)
     .language_mode(LanguageMode::Detect)
     .build();

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -296,6 +296,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "language_detection")]
     fn it_keeps_numbers() {
         let text = "42 1337";
         let tokenizer = Tokenizer::new(&LanguageMode::Detect);
@@ -334,6 +335,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "language_detection")]
     fn it_handles_empty_input() {
         let text = "";
         let tokenizer = Tokenizer::new(&LanguageMode::Detect);
@@ -344,6 +346,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "language_detection")]
     fn it_detects_english() {
         let tokens_detected = tokenize_recipes("recipes_en.csv", LanguageMode::Detect);
         let tokens_en = tokenize_recipes("recipes_en.csv", LanguageMode::Fixed(Language::English));
@@ -352,6 +355,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "language_detection")]
     fn it_detects_german() {
         let tokens_detected = tokenize_recipes("recipes_de.csv", LanguageMode::Detect);
         let token_de = tokenize_recipes("recipes_de.csv", LanguageMode::Fixed(Language::German));


### PR DESCRIPTION
Disclaimer: I don't have much experience with cargo features.

When pulling the project and running `cargo test`, there are failing tests as the `language_detection` is not enabled per default. Also, rust analyzer complains about these tests. This commit makes silences the warnings and makes `cargo test` run, but I might be missing a step when setting this project up.